### PR TITLE
Cleanup composer.json for 0.0.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "ircmaxell/security-lib",
     "type": "library",
-	"version": "0.0.1-beta1",
     "description": "A Base Security Library",
     "keywords": [],
     "homepage": "https://github.com/ircmaxell/PHP-SecurityLib",
@@ -22,6 +21,11 @@
     "autoload": {
         "psr-0": {
             "SecurityLib": "lib"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.0.x-dev"
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,5 +1,9 @@
 {
-    "hash": "c6ce813d02e1f8bc10f33064ac821a79",
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+    ],
+    "hash": "ae495ddbabf82221183017affaf45a7a",
     "packages": [
 
     ],
@@ -21,7 +25,6 @@
             "require": {
                 "php": ">=5.3.0"
             },
-            "time": "2012-08-25 05:49:29",
             "type": "library",
             "autoload": {
                 "psr-0": {
@@ -32,7 +35,8 @@
             "license": [
                 "BSD"
             ],
-            "homepage": "http://vfs.bovigo.org/"
+            "homepage": "http://vfs.bovigo.org/",
+            "time": "2012-08-25 05:49:29"
         }
     ],
     "aliases": [
@@ -40,6 +44,12 @@
     ],
     "minimum-stability": "stable",
     "stability-flags": [
+
+    ],
+    "platform": {
+        "php": ">=5.3.2"
+    },
+    "platform-dev": [
 
     ]
 }


### PR DESCRIPTION
Removed 0.0.1-beta1 version as it was not actually doing anything. Added a branch alias that will enable people to require:

```
"ircmaxell/security-lib": "0.0.*@dev"
```

An unintended side effect of composer.json changes is that it results in composer.lock needing to change to account for a different hash. In addition, Composer sometimes actually changes other aspects of the composer.lock
structure.

---

I'll be sending another PR to cleanup composer.json for v1.0 branch.

If the v1.0 branch is going to be the primary branch going forward (since it looks slightly newer) it might make sense to either change the default branch on githup to be v1.0 instead of master or else rename:
- master -> 0.0
- v1.0 -> master

The latter seems to be what a lot of people do, but I think it is up to personal taste. It is, however, difficult to figure out what is going on as it stands currently. master is actually, as far as I can tell, older code... and that is what I get shown when I first visit the github page.
