### PR TITLE
Cleanup composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "ircmaxell/security-lib",
     "type": "library",
-	"version": "1.0.0",
     "description": "A Base Security Library",
     "keywords": [],
     "homepage": "https://github.com/ircmaxell/PHP-SecurityLib",

--- a/composer.lock
+++ b/composer.lock
@@ -1,5 +1,9 @@
 {
-    "hash": "c6ce813d02e1f8bc10f33064ac821a79",
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+    ],
+    "hash": "3360b0e3cf4b4265471d8b76010b31aa",
     "packages": [
 
     ],
@@ -21,7 +25,6 @@
             "require": {
                 "php": ">=5.3.0"
             },
-            "time": "2012-08-25 05:49:29",
             "type": "library",
             "autoload": {
                 "psr-0": {
@@ -32,7 +35,8 @@
             "license": [
                 "BSD"
             ],
-            "homepage": "http://vfs.bovigo.org/"
+            "homepage": "http://vfs.bovigo.org/",
+            "time": "2012-08-25 05:49:29"
         }
     ],
     "aliases": [
@@ -40,6 +44,12 @@
     ],
     "minimum-stability": "stable",
     "stability-flags": [
+
+    ],
+    "platform": {
+        "php": ">=5.3.2"
+    },
+    "platform-dev": [
 
     ]
 }


### PR DESCRIPTION
The version tag is not required since the branch is named like 1.0 it will automatically receive the 1.0.x-dev treatment by Composer.

An unintended side effect of composer.json changes is that it results in composer.lock needing to change to account for a different hash. In addition, Composer sometimes actually changes other aspects of the composer.lock
structure.

---

This goes with the other set of PR's. We can talk more about which direction you'd like to go. I'd suggest moving this branch to be the default branch for people who visit this project if this is going to be the current working branch for this project. Would be the lowest impact thing to do to get this squared away.
