### PR TITLE
Fix homepage in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "library",
     "description": "A Base Security Library",
     "keywords": [],
-    "homepage": "https://github.com/ircmaxell/PHP-SecurityLib",
+    "homepage": "https://github.com/ircmaxell/SecurityLib",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
The current URL https://github.com/ircmaxell/PHP-SecurityLib ends in a 404 error.
