### PR TITLE
Changed AbstractFactory::loadFiles to callable typehint

### DIFF
--- a/lib/SecurityLib/AbstractFactory.php
+++ b/lib/SecurityLib/AbstractFactory.php
@@ -64,7 +64,7 @@ abstract class AbstractFactory {
      *
      * @param string $directory The directory to search for classes in
      * @param string $namespace The namespace prefix for any found classes
-     * @param string $callback  The callback with which to register the class
+     * @param callable $callback  The callback with which to register the class
      *
      * @return void
      */


### PR DESCRIPTION
Otherwise, type checkers complain, `array()` is not a `string`.

Specifically: https://scrutinizer-ci.com/g/ircmaxell/RandomLib/inspections/3c45e532-0d7f-4d6b-a43f-2202292ae75e/issues/files/lib/RandomLib/Factory.php?status=existing&orderField=path&order=asc